### PR TITLE
Set exitCode instead of calling exit() directly in VM configurations.

### DIFF
--- a/lib/compact_vm_config.dart
+++ b/lib/compact_vm_config.dart
@@ -84,10 +84,8 @@ class CompactVMConfiguration extends VMConfiguration {
   void onDone(bool success) {
     // Override and don't call the superclass onDone() to avoid printing the
     // "unittest-suite-..." boilerplate.
-    Future.wait([stdout.close(), stderr.close()]).then((_) {
-      _receivePort.close();
-      exit(success ? 0 : 1);
-    });
+    exitCode = success ? 0 : 1;
+    _receivePort.close();
   }
 
   void onSummary(int passed, int failed, int errors, List<TestCase> results,

--- a/lib/vm_config.dart
+++ b/lib/vm_config.dart
@@ -43,18 +43,14 @@ class VMConfiguration extends SimpleConfiguration {
   }
 
   void onDone(bool success) {
-    int status;
     try {
       super.onDone(success);
-      status = 0;
+      exitCode = 0;
     } catch (ex) {
       // A non-zero exit code is used by the test infrastructure to detect
       // failure.
-      status = 1;
+      exitCode = 1;
     }
-    Future.wait([stdout.close(), stderr.close()]).then((_) {
-      exit(status);
-    });
   }
 }
 


### PR DESCRIPTION
This avoids side-effects of terminating the VM, such as preventing coverage collection and other interaction with the VM observatory.