### PR TITLE
Support document.readyState value: "complete"

### DIFF
--- a/lib/test_controller.js
+++ b/lib/test_controller.js
@@ -160,7 +160,7 @@ function externalError(e) {
 }
 
 document.addEventListener('readystatechange', function () {
-  if (document.readyState != "loaded") return;
+  if (document.readyState != "loaded" && document.readyState != "complete") return;
   // If 'startedDartTest' is not set, that means that the test did not have
   // a chance to load. This will happen when a load error occurs in the VM.
   // Give the machine time to start up.

--- a/lib/test_controller.js
+++ b/lib/test_controller.js
@@ -160,7 +160,8 @@ function externalError(e) {
 }
 
 document.addEventListener('readystatechange', function () {
-  if (document.readyState != "loaded" && document.readyState != "complete") return;
+  if (document.readyState != "loaded"
+      && document.readyState != "complete") return;
   // If 'startedDartTest' is not set, that means that the test did not have
   // a chance to load. This will happen when a load error occurs in the VM.
   // Give the machine time to start up.


### PR DESCRIPTION
Some browsers (like content_shell) don't use readyState = "loaded" but readyState = "complete" instead.

This causes Content_shell to hang if no tests are being ran because notifyDone() is never called in that case.